### PR TITLE
feat: release

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "eslint": "^8.16.0",
     "eslint-plugin-import": "^2.26.0",
     "nock": "^13.2.4",
-    "rollup": "^2.75.4",
+    "rollup": "^2.75.5",
     "typescript": "^4.7.2",
     "vitest": "^0.13.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1732,10 +1732,10 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-rollup@^2.59.0, rollup@^2.75.4:
-  version "2.75.4"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.75.4.tgz#c3518c326c98e508b628a93015a03a276c331f22"
-  integrity sha512-JgZiJMJkKImMZJ8ZY1zU80Z2bA/TvrL/7D9qcBCrfl2bP+HUaIw0QHUroB4E3gBpFl6CRFM1YxGbuYGtdAswbQ==
+rollup@^2.59.0, rollup@^2.75.5:
+  version "2.75.5"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.75.5.tgz#7985c1962483235dd07966f09fdad5c5f89f16d0"
+  integrity sha512-JzNlJZDison3o2mOxVmb44Oz7t74EfSd1SQrplQk0wSaXV7uLQXtVdHbxlcT3w+8tZ1TL4r/eLfc7nAbz38BBA==
   optionalDependencies:
     fsevents "~2.3.2"
 


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/technote-space/github-action-config-helper/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>cli.js -u --packageFile package.json</em></summary>

```Shell
Using yarn
Upgrading /home/runner/work/github-action-config-helper/github-action-config-helper/package.json

 rollup  ^2.75.4  →  ^2.75.5     

Run yarn install to install new versions.
```



</details>
<details>
<summary><em>yarn install</em></summary>

```Shell
yarn install v1.22.18
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
Done in 9.02s.
```

### stderr:

```Shell
warning " > @octokit/plugin-rest-endpoint-methods@5.13.0" has unmet peer dependency "@octokit/core@>=3".
warning " > @rollup/plugin-typescript@8.3.2" has unmet peer dependency "tslib@*".
```

</details>
<details>
<summary><em>yarn upgrade</em></summary>

```Shell
yarn upgrade v1.22.18
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Rebuilding all packages...
success Saved lockfile.
success Saved 213 new dependencies.
info Direct dependencies
├─ @rollup/plugin-typescript@8.3.2
├─ @sindresorhus/tsconfig@3.0.1
├─ @technote-space/github-action-helper@5.3.7
├─ @technote-space/github-action-test-helper@0.9.7
├─ @types/js-yaml@4.0.5
├─ @types/node@17.0.38
├─ @typescript-eslint/eslint-plugin@5.27.0
├─ @typescript-eslint/parser@5.27.0
├─ c8@7.11.3
├─ eslint-plugin-import@2.26.0
├─ eslint@8.16.0
├─ nock@13.2.4
├─ rollup@2.75.5
└─ typescript@4.7.2
info All dependencies
├─ @bcoe/v8-coverage@0.2.3
├─ @eslint/eslintrc@1.3.0
├─ @humanwhocodes/config-array@0.9.5
├─ @humanwhocodes/object-schema@1.2.1
├─ @istanbuljs/schema@0.1.3
├─ @jridgewell/resolve-uri@3.0.7
├─ @jridgewell/sourcemap-codec@1.4.13
├─ @jridgewell/trace-mapping@0.3.13
├─ @nodelib/fs.scandir@2.1.5
├─ @nodelib/fs.stat@2.0.5
├─ @nodelib/fs.walk@1.2.8
├─ @octokit/auth-token@2.5.0
├─ @octokit/core@3.6.0
├─ @octokit/endpoint@6.0.12
├─ @octokit/graphql@4.8.0
├─ @octokit/plugin-paginate-rest@2.17.0
├─ @octokit/request-error@2.1.0
├─ @octokit/request@5.6.3
├─ @rollup/plugin-typescript@8.3.2
├─ @rollup/pluginutils@3.1.0
├─ @sindresorhus/tsconfig@3.0.1
├─ @technote-space/github-action-helper@5.3.7
├─ @technote-space/github-action-log-helper@0.2.5
├─ @technote-space/github-action-test-helper@0.9.7
├─ @types/chai-subset@1.3.3
├─ @types/chai@4.3.1
├─ @types/estree@0.0.39
├─ @types/istanbul-lib-coverage@2.0.4
├─ @types/js-yaml@4.0.5
├─ @types/json-schema@7.0.11
├─ @types/json5@0.0.29
├─ @types/node@17.0.38
├─ @typescript-eslint/eslint-plugin@5.27.0
├─ @typescript-eslint/parser@5.27.0
├─ @typescript-eslint/type-utils@5.27.0
├─ acorn-jsx@5.3.2
├─ acorn@8.7.1
├─ ajv@6.12.6
├─ ansi-regex@5.0.1
├─ ansi-styles@4.3.0
├─ argparse@2.0.1
├─ array-includes@3.1.5
├─ array-union@2.1.0
├─ array.prototype.flat@1.3.0
├─ assertion-error@1.1.0
├─ balanced-match@1.0.2
├─ before-after-hook@2.2.2
├─ brace-expansion@1.1.11
├─ braces@3.0.2
├─ c8@7.11.3
├─ callsites@3.1.0
├─ chai@4.3.6
├─ chalk@4.1.2
├─ check-error@1.0.2
├─ cliui@7.0.4
├─ color-convert@2.0.1
├─ color-name@1.1.4
├─ concat-map@0.0.1
├─ convert-source-map@1.8.0
├─ cross-spawn@7.0.3
├─ debug@4.3.4
├─ deep-eql@3.0.1
├─ deep-is@0.1.4
├─ deprecation@2.3.1
├─ dir-glob@3.0.1
├─ doctrine@2.1.0
├─ emoji-regex@8.0.0
├─ es-shim-unscopables@1.0.0
├─ es-to-primitive@1.2.1
├─ esbuild-linux-64@0.14.42
├─ esbuild@0.14.42
├─ escalade@3.1.1
├─ escape-string-regexp@4.0.0
├─ eslint-import-resolver-node@0.3.6
├─ eslint-module-utils@2.7.3
├─ eslint-plugin-import@2.26.0
├─ eslint-scope@7.1.1
├─ eslint@8.16.0
├─ esquery@1.4.0
├─ estraverse@5.3.0
├─ estree-walker@1.0.1
├─ fast-deep-equal@3.1.3
├─ fast-glob@3.2.11
├─ fast-json-stable-stringify@2.1.0
├─ fast-levenshtein@2.0.6
├─ fastq@1.13.0
├─ file-entry-cache@6.0.1
├─ fill-range@7.0.1
├─ find-up@5.0.0
├─ flat-cache@3.0.4
├─ flatted@3.2.5
├─ foreground-child@2.0.0
├─ fs.realpath@1.0.0
├─ function.prototype.name@1.1.5
├─ get-caller-file@2.0.5
├─ get-symbol-description@1.0.0
├─ glob-parent@6.0.2
├─ glob@7.2.3
├─ globby@11.1.0
├─ has-bigints@1.0.2
├─ has-flag@4.0.0
├─ html-escaper@2.0.2
├─ import-fresh@3.3.0
├─ imurmurhash@0.1.4
├─ inflight@1.0.6
├─ inherits@2.0.4
├─ internal-slot@1.0.3
├─ is-bigint@1.0.4
├─ is-boolean-object@1.1.2
├─ is-callable@1.2.4
├─ is-date-object@1.0.5
├─ is-extglob@2.1.1
├─ is-fullwidth-code-point@3.0.0
├─ is-negative-zero@2.0.2
├─ is-number-object@1.0.7
├─ is-number@7.0.0
├─ is-regex@1.1.4
├─ is-shared-array-buffer@1.0.2
├─ is-string@1.0.7
├─ is-symbol@1.0.4
├─ is-weakref@1.0.2
├─ isexe@2.0.0
├─ istanbul-lib-coverage@3.2.0
├─ istanbul-reports@3.1.4
├─ json-schema-traverse@0.4.1
├─ json-stable-stringify-without-jsonify@1.0.1
├─ json-stringify-safe@5.0.1
├─ json5@1.0.1
├─ local-pkg@0.4.1
├─ locate-path@6.0.0
├─ lodash.merge@4.6.2
├─ lodash.set@4.3.2
├─ loupe@2.3.4
├─ lru-cache@6.0.0
├─ make-dir@3.1.0
├─ merge2@1.4.1
├─ micromatch@4.0.5
├─ minimist@1.2.6
├─ ms@2.1.2
├─ nanoid@3.3.4
├─ natural-compare@1.4.0
├─ nock@13.2.4
├─ node-fetch@2.6.7
├─ object-inspect@1.12.2
├─ object.assign@4.1.2
├─ object.values@1.1.5
├─ optionator@0.9.1
├─ p-limit@3.1.0
├─ p-locate@5.0.0
├─ p-try@1.0.0
├─ parent-module@1.0.1
├─ path-exists@4.0.0
├─ path-is-absolute@1.0.1
├─ path-key@3.1.1
├─ path-parse@1.0.7
├─ path-type@4.0.0
├─ pathval@1.1.1
├─ picocolors@1.0.0
├─ picomatch@2.3.1
├─ postcss@8.4.14
├─ propagate@2.0.1
├─ punycode@2.1.1
├─ queue-microtask@1.2.3
├─ regexp.prototype.flags@1.4.3
├─ require-directory@2.1.1
├─ resolve-from@4.0.0
├─ resolve@1.22.0
├─ reusify@1.0.4
├─ rollup@2.75.5
├─ run-parallel@1.2.0
├─ safe-buffer@5.1.2
├─ shebang-command@2.0.0
├─ shebang-regex@3.0.0
├─ shell-escape@0.2.0
├─ side-channel@1.0.4
├─ signal-exit@3.0.7
├─ slash@3.0.0
├─ source-map-js@1.0.2
├─ string-width@4.2.3
├─ string.prototype.trimend@1.0.5
├─ string.prototype.trimstart@1.0.5
├─ strip-bom@3.0.0
├─ strip-json-comments@3.1.1
├─ supports-preserve-symlinks-flag@1.0.0
├─ test-exclude@6.0.0
├─ text-table@0.2.0
├─ tinypool@0.1.3
├─ tinyspy@0.3.2
├─ to-regex-range@5.0.1
├─ tr46@0.0.3
├─ tsconfig-paths@3.14.1
├─ tslib@1.14.1
├─ tunnel@0.0.6
├─ type-check@0.4.0
├─ type-detect@4.0.8
├─ type-fest@0.20.2
├─ typescript@4.7.2
├─ unbox-primitive@1.0.2
├─ uri-js@4.4.1
├─ v8-compile-cache@2.3.0
├─ v8-to-istanbul@9.0.0
├─ vite@2.9.9
├─ webidl-conversions@3.0.1
├─ whatwg-url@5.0.0
├─ which-boxed-primitive@1.0.2
├─ which@2.0.2
├─ word-wrap@1.2.3
├─ wrap-ansi@7.0.0
├─ y18n@5.0.8
├─ yallist@4.0.0
├─ yargs-parser@20.2.9
├─ yargs@16.2.0
└─ yocto-queue@0.1.0
Done in 6.32s.
```

### stderr:

```Shell
warning " > @octokit/plugin-rest-endpoint-methods@5.13.0" has unmet peer dependency "@octokit/core@>=3".
warning " > @rollup/plugin-typescript@8.3.2" has unmet peer dependency "tslib@*".
```

</details>
<details>
<summary><em>yarn audit</em></summary>

```Shell
yarn audit v1.22.18
0 vulnerabilities found - Packages audited: 305
Done in 0.47s.
```



</details>

</details>

## Changed files
<details>
<summary>Changed 2 files: </summary>

- package.json
- yarn.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)